### PR TITLE
Fix GitHub spelling

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
     <div class="overlay"></div>
     <nav>
         <a href="https://docs.helix-editor.com">Documentation</a>
-        <a href="https://github.com/helix-editor/helix">Github</a>
+        <a href="https://github.com/helix-editor/helix">GitHub</a>
     </nav>
     <article>
         <h1 class="title">Helix</h1>
@@ -148,7 +148,7 @@
       <hr/>
       <section class="content">
         <h2><strong>Support</strong></h2>
-            <p>Contribute code on <a href="https://github.com/helix-editor/helix">Github</a>.</p>
+            <p>Contribute code on <a href="https://github.com/helix-editor/helix">GitHub</a>.</p>
             <p>Discuss the project on <a href="https://matrix.to/#/#helix-community:matrix.org">Matrix</a>.</p>
             <!--<p>Donate to fund development.</a>-->
       </section>


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.