### PR TITLE
generate an atom feed for the news section

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,9 @@ compile_sass = false
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = true
 
+# Generate an RSS feed
+generate_feed = true
+
 [markdown]
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,9 @@
     <style> </style>
     <link href="/style.css" rel="stylesheet">
     <link href="/asciinema-player.css" rel="stylesheet">
+    {% block rss %}
+      <link rel="alternate" type="application/atom+xml" title="Atom" href="{{ get_url(path="atom.xml", trailing_slash=false) }}">
+    {% endblock %}
   </head>
   <body>
     <div class="overlay"></div>


### PR DESCRIPTION
This was recommended on the [lobste.rs post](https://lobste.rs/s/8hxvk2/helix_22_03_released_modal_terminal_based#c_fyvway) and it turns out it's very easy to enable in Zola. See the [feeds docs](https://www.getzola.org/documentation/templates/feeds/). It defaults to creating a `/atom.xml` route with the feed and we point to that with a `link` to enable auto-discovery by some RSS readers.