### PR TITLE
Fix typo in 2022-08-31-release-22.08-highlights.md

### DIFF
--- a/content/news/2022-08-31-release-22.08-highlights.md
+++ b/content/news/2022-08-31-release-22.08-highlights.md
@@ -20,7 +20,7 @@ Let's check out the highlighted features for 22.08.
 {{ asciinema(id="indent-guides", width="94", height="25") }}
 
 Indent guides provide a visual representation for the current indentation
-level. Enable indent guides with the `editor.indent-guide.render` key.
+level. Enable indent guides with the `editor.indent-guides.render` key.
 The character used as a guide is also customizable.
 
 ## Cursorline


### PR DESCRIPTION
Fix typo in `indent-guides`