### PR TITLE
Configure title & description

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,10 @@ build_search_index = true
 # Generate an RSS feed
 generate_feed = true
 
+# The site title and description; used in feeds by default.
+title = "Helix"
+description = "A post-modern modal text editor."
+
 [markdown]
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Helix</title>
-    <meta name="description" content="A post-modern modal text editor.">
+    <title>{{ config.title }}</title>
+    <meta name="description" content="{{ config.description }}">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="icon" type="image/png" href="/favicon.png">
     <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
* Adjustments found while investigating getzola/zola#2024
* Zola uses both values when generating atom.xml, despite being marked optional.
* Have base.html also use the same metadata.