### PR TITLE
Fix link to nucleo in release notes

### DIFF
--- a/content/news/2023-10-25-release-23.10-highlights.md
+++ b/content/news/2023-10-25-release-23.10-highlights.md
@@ -62,7 +62,7 @@ See more details in the [language configuration docs](https://docs.helix-editor.
 Helix uses "fuzzy" matching to filter as-you-type in components like the file
 picker. Previously we used the popular `skim`/`fuzzy-matcher` crates but in the
 23.10 release we've switched to the new
-[`nucleo`](https://github.com/helix-editor/helix) crate. Nucleo is
+[`nucleo`](https://github.com/helix-editor/nucleo) crate. Nucleo is
 significantly faster than skim and fzf, handles Unicode correctly, and uses a
 bonus system that feels more intuitive.
 


### PR DESCRIPTION
Hi, 
I just read the release notes and noticed that there is a link that is wrong. When they talk about `nucleo`, it points to the wrong repo.