### PR TITLE
Fix links menu responsiveness on mobile, fix feeds config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ compile_sass = false
 build_search_index = true
 
 # Generate an RSS feed
-generate_feed = true
+generate_feeds = true
 
 # The site title, author and description; used in feeds by default.
 title = "Helix"

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
           <h1>Helix</h1>
         </a>
         <div style="flex: 1"></div>
-        <menu>
+        <menu style="display: flex; flex-wrap: wrap;">
           <a href="/news">News</a>
           <a href="https://docs.helix-editor.com">Documentation</a>
           <a href="https://github.com/helix-editor/helix">GitHub</a>


### PR DESCRIPTION
* Fixes responsiveness of the links menu on small screens. Previously, links were extending beyond the width of the page on mobile devices.
* Replaces `generate_feed` with `generate_feeds` in `config.toml` as per [zola's documentation](https://www.getzola.org/documentation/templates/feeds/).