### PR TITLE
Bump Zola to 0.19.2

### DIFF
--- a/.github/workflows/zola.yml
+++ b/.github/workflows/zola.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Zola
         run: wget -q -O - "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | sudo tar xzf - -C /usr/local/bin
         env:
-          ZOLA_VERSION: 0.17.1
+          ZOLA_VERSION: 0.19.2
       - name: Build
         run: zola build
       - name: Deploy


### PR DESCRIPTION
The `generate_feed` option was renamed to `generate_feeds` in version 0.19, so this update should fix the atom feed. Ref https://github.com/helix-editor/website/commit/ffbf0d3de79f54adf5dbd12fc351c1bea7275536#commitcomment-145584952