### PR TITLE
Fix "selling point" links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,8 +28,8 @@
 
           <div class="selling-point">
             <h2>Powerful code manipulation</h2>
-            <a href="https://docs.helix-editor.com/usage.html#tree-sitter-textobject-based-navigation">
-            Navigate</a> and <a href="https://docs.helix-editor.com/usage.html#textobjects">select</a>
+            <a href="https://docs.helix-editor.com/syntax-aware-motions.html">
+            Navigate</a> and <a href="https://docs.helix-editor.com/textobjects.html">select</a>
             functions, classes, comments, etc and select syntax tree nodes instead of plain text.
           </div>
 


### PR DESCRIPTION
The old links lead to the old way the usage page were built.