### PR TITLE
Set title for news index and posts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ config.title }}</title>
+    <title>
+      {% block title %}{% if page.title %}{{ page.title }} | {% endif %} {{ config.title }}{% endblock %}
+    </title>
     <meta name="description" content="{{ config.description }}">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <link rel="icon" type="image/png" href="/favicon.png">

--- a/templates/news.html
+++ b/templates/news.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}News | {{ super() }}{% endblock %}
+
 {% block content %}
 <style>
 .post-header {


### PR DESCRIPTION
When I posted the release notes on Bluesky, the title did not reflect the post title.

<img width="295" alt="image" src="https://github.com/user-attachments/assets/1e5605d1-4a73-4c00-8040-a0a263b1044f" />

This PR sets the HTML `<title>` for the news index to `News | Helix` and for the individual posts to, e.g., `Release 25.01 Highlights | Helix`. Obviously the separator could be changed. I didn't see any pattern to follow on the docs site.

<img width="315" alt="image" src="https://github.com/user-attachments/assets/e5cab416-5b52-4b21-8a37-1248cca30b00" />

<img width="398" alt="image" src="https://github.com/user-attachments/assets/7dea2367-97c1-4df7-92d1-3e0887543ddf" />

<img width="189" alt="image" src="https://github.com/user-attachments/assets/61ae0b21-379c-46b3-93dc-0ec36448dff6" />
